### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.0
+torch>=2.0,<=2.5
 torchvision>=0.15.1
 smplx==0.1.28
 timm


### PR DESCRIPTION
In pytorch 2.6+, the default for torch.load's `weights_only` parameter is `False`. Wilor's codebase dependency, specifically Ultralytics, will only work with `weights_only=True`. 

Adding a max version limit to torch prevents this issue.