### PR TITLE
Fix inference

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,8 +21,8 @@ def test_wilor_model():
     pipe = WiLorHandPose3dEstimationPipeline(device=device, dtype=dtype, verbose=False)
     img_path = "assets/img.png"
     image = cv2.imread(img_path)
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     outputs = pipe.predict(image)
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     hand_bboxs = []
     is_rights = []
     for i in range(len(outputs)):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -302,11 +302,11 @@ def test_wilor_image_pipeline():
     pipe = WiLorHandPose3dEstimationPipeline(device=device, dtype=dtype, verbose=False)
     img_path = "assets/img.png"
     image = cv2.imread(img_path)
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     for _ in range(20):
         t0 = time.time()
         outputs = pipe.predict(image)
         print(time.time() - t0)
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     save_dir = "./results"
     os.makedirs(save_dir, exist_ok=True)
     renderer = Renderer(pipe.wilor_model.mano.faces)
@@ -381,11 +381,11 @@ def test_wilor_video_pipeline():
         ret, frame = cap.read()
         if not ret:
             break
-
+        
+        outputs = pipe.predict(frame)
         # Convert frame to RGB
         image = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         t0 = time.time()
-        outputs = pipe.predict(image)
         print(time.time() - t0)
         render_image = image.copy()
         render_image = render_image.astype(np.float32)[:, :, ::-1] / 255.0


### PR DESCRIPTION
WiLoR-mini erroneously converted from opencv's default BGR to RGB while running inference. This PR fixes that.
The effects of this error is visible in the provided example video. The results after the fix is appended below for your reference.
You may refer to the original repo's demo.py pipeline for more information.

https://github.com/user-attachments/assets/d185888c-fe42-4960-8d0c-1fd245fe8f35

