### PR TITLE
Relax `torch` and update `ultralytics` dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-torch>=2.0,<=2.5
+torch>=2.0
 torchvision>=0.15.1
 smplx==0.1.28
 timm
 einops
-ultralytics==8.1.34
+ultralytics>=8.3.4
 opencv-python
 huggingface_hub
 scikit-image


### PR DESCRIPTION
Supports any torch>=2.0, and changes ultralytics minimum version to avoid errors regarding the default `weights_only=False` in `torch.load` for newer torch versions.