### PR TITLE
Fix dependencies; Accept focal as input; Return detection confidence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-torch>=2.0,<=2.5
+torch>=2.0
 torchvision>=0.15.1
 smplx==0.1.28
 timm
 einops
-ultralytics==8.1.34
+ultralytics>=8.3.4
 opencv-python
 huggingface_hub
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ smplx==0.1.28
 timm
 einops
 ultralytics>=8.3.4
+dill # needed to load the detector with ultralytics
 opencv-python
 huggingface_hub
 scikit-image
 roma
-chumpy @ git+https://github.com/mattloper/chumpy
+chumpy @ git+https://github.com/mattloper/chumpy@357a9544d88e88dac729ba3351a1d9395a38b220

--- a/wilor_mini/pipelines/wilor_hand_pose3d_estimation_pipeline.py
+++ b/wilor_mini/pipelines/wilor_hand_pose3d_estimation_pipeline.py
@@ -86,7 +86,11 @@ class WiLorHandPose3dEstimationPipeline:
             hand_bbox = det.boxes.data.cpu().detach().squeeze().numpy()
             is_rights.append(det.boxes.cls.cpu().detach().squeeze().item())
             bboxes.append(hand_bbox[:4].tolist())
-            detect_rets.append({"hand_bbox": bboxes[-1], "is_right": is_rights[-1]})
+            detect_rets.append({
+                "hand_bbox": bboxes[-1],
+                "is_right": is_rights[-1],
+                "hand_conf": det.boxes.conf.cpu().detach().squeeze().item(),
+            })
 
         if len(bboxes) == 0:
             self.logger.warn("No hand detected!")

--- a/wilor_mini/pipelines/wilor_hand_pose3d_estimation_pipeline.py
+++ b/wilor_mini/pipelines/wilor_hand_pose3d_estimation_pipeline.py
@@ -144,7 +144,7 @@ class WiLorHandPose3dEstimationPipeline:
                 wilor_output_i["hand_pose"] = np.concatenate(
                     (wilor_output_i["hand_pose"][:, :, 0:1], -wilor_output_i["hand_pose"][:, :, 1:3]),
                     axis=-1)
-            scaled_focal_length = self.FOCAL_LENGTH / self.IMAGE_SIZE * img_size.max()
+            scaled_focal_length = kwargs.get("focal_length", self.FOCAL_LENGTH / self.IMAGE_SIZE * img_size.max())
             pred_cam_t_full = utils.cam_crop_to_full(pred_cam, box_center[None], bbox_size, img_size[None],
                                                      scaled_focal_length)
             wilor_output_i["pred_cam_t_full"] = pred_cam_t_full
@@ -221,7 +221,7 @@ class WiLorHandPose3dEstimationPipeline:
                 wilor_output_i["hand_pose"] = np.concatenate(
                     (wilor_output_i["hand_pose"][:, :, 0:1], -wilor_output_i["hand_pose"][:, :, 1:3]),
                     axis=-1)
-            scaled_focal_length = self.FOCAL_LENGTH / self.IMAGE_SIZE * img_size.max()
+            scaled_focal_length = kwargs.get("focal_length", self.FOCAL_LENGTH / self.IMAGE_SIZE * img_size.max())
             pred_cam_t_full = utils.cam_crop_to_full(pred_cam, box_center[None], bbox_size, img_size[None],
                                                      scaled_focal_length)
             wilor_output_i["pred_cam_t_full"] = pred_cam_t_full


### PR DESCRIPTION
### Dependencies fix
Supports any torch>=2.0, and changes ultralytics minimum version to avoid errors regarding the default weights_only=False in torch.load for newer torch versions. Also, pins the chumpy version to https://github.com/mattloper/chumpy/pull/62 for easy install.

Fixes: #18 

### Focal input
Accepts focal_length as an inference input

### Detection confidence
Returns the detection confidence from YOLO to the output dict