### PR TITLE
Fix MPS tensor layout for WiLoR inference

### DIFF
--- a/tests/test_mps_layout.py
+++ b/tests/test_mps_layout.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import importlib
 import sys
 import types
 
@@ -7,25 +8,68 @@ import torch
 from torch import nn
 
 
-roma_stub = types.ModuleType("roma")
-roma_stub.rotmat_to_rotvec = lambda rotmats: torch.zeros(
-    *rotmats.shape[:-2], 3, device=rotmats.device, dtype=rotmats.dtype
-)
-sys.modules.setdefault("roma", roma_stub)
+@pytest.fixture()
+def lightweight_model_imports():
+    module_names = [
+        "roma",
+        "wilor_mini.models.vit",
+        "wilor_mini.models.mano_wrapper",
+        "wilor_mini.models.refinement_net",
+        "wilor_mini.models.wilor",
+    ]
+    sentinel = object()
+    previous_modules = {
+        name: sys.modules.get(name, sentinel)
+        for name in module_names
+    }
 
-vit_stub = types.ModuleType("wilor_mini.models.vit")
-vit_stub.vit = lambda **kwargs: None
-vit_stub.rot6d_to_rotmat = lambda x: x.reshape(-1, 2, 3).new_zeros(
-    x.shape[0], 3, 3
-)
-sys.modules.setdefault("wilor_mini.models.vit", vit_stub)
+    models_package = importlib.import_module("wilor_mini.models")
+    previous_attrs = {
+        name: getattr(models_package, name, sentinel)
+        for name in ("vit", "mano_wrapper", "refinement_net", "wilor")
+    }
 
-mano_wrapper_stub = types.ModuleType("wilor_mini.models.mano_wrapper")
-mano_wrapper_stub.MANO = lambda *args, **kwargs: None
-sys.modules.setdefault("wilor_mini.models.mano_wrapper", mano_wrapper_stub)
+    for name in module_names:
+        sys.modules.pop(name, None)
+    for name in previous_attrs:
+        if previous_attrs[name] is not sentinel:
+            delattr(models_package, name)
 
-from wilor_mini.models.refinement_net import DeConvNet, DeConvNet_v2
-from wilor_mini.models.wilor import WiLor
+    roma_stub = types.ModuleType("roma")
+    roma_stub.rotmat_to_rotvec = lambda rotmats: torch.zeros(
+        *rotmats.shape[:-2], 3, device=rotmats.device, dtype=rotmats.dtype
+    )
+
+    vit_stub = types.ModuleType("wilor_mini.models.vit")
+    vit_stub.vit = lambda **kwargs: None
+    vit_stub.rot6d_to_rotmat = lambda x: x.reshape(-1, 2, 3).new_zeros(
+        x.shape[0], 3, 3
+    )
+
+    mano_wrapper_stub = types.ModuleType("wilor_mini.models.mano_wrapper")
+    mano_wrapper_stub.MANO = lambda *args, **kwargs: None
+
+    sys.modules["roma"] = roma_stub
+    sys.modules["wilor_mini.models.vit"] = vit_stub
+    sys.modules["wilor_mini.models.mano_wrapper"] = mano_wrapper_stub
+
+    refinement_net = importlib.import_module("wilor_mini.models.refinement_net")
+    wilor = importlib.import_module("wilor_mini.models.wilor")
+
+    try:
+        yield wilor.WiLor, refinement_net
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        for name, module in previous_modules.items():
+            if module is not sentinel:
+                sys.modules[name] = module
+        for name in ("vit", "mano_wrapper", "refinement_net", "wilor"):
+            if hasattr(models_package, name):
+                delattr(models_package, name)
+        for name, value in previous_attrs.items():
+            if value is not sentinel:
+                setattr(models_package, name, value)
 
 
 class _ContiguousBackbone(nn.Module):
@@ -101,7 +145,10 @@ class _AssertContiguous(nn.Module):
 
 
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is required")
-def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps():
+def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps(
+    lightweight_model_imports,
+):
+    WiLor, _ = lightweight_model_imports
     model = WiLor.__new__(WiLor)
     nn.Module.__init__(model)
     model.backbone = _ContiguousBackbone()
@@ -124,11 +171,14 @@ def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps():
     assert output["pred_keypoints_3d"].shape == (1, 21, 3)
 
 
-@pytest.mark.parametrize("deconv_cls", [DeConvNet, DeConvNet_v2])
+@pytest.mark.parametrize("deconv_cls_name", ["DeConvNet", "DeConvNet_v2"])
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is required")
 def test_refinement_deconv_makes_image_features_contiguous_before_first_conv_on_mps(
-    deconv_cls,
+    deconv_cls_name,
+    lightweight_model_imports,
 ):
+    _, refinement_net = lightweight_model_imports
+    deconv_cls = getattr(refinement_net, deconv_cls_name)
     deconv = deconv_cls(feat_dim=8)
     deconv.first_conv = _AssertContiguous()
     deconv.deconv = (

--- a/tests/test_mps_layout.py
+++ b/tests/test_mps_layout.py
@@ -8,6 +8,11 @@ import torch
 from torch import nn
 
 
+DEVICES = ["cpu"]
+if torch.backends.mps.is_available():
+    DEVICES.append("mps")
+
+
 @pytest.fixture()
 def lightweight_model_imports():
     module_names = [
@@ -73,11 +78,15 @@ def lightweight_model_imports():
 
 
 class _ContiguousBackbone(nn.Module):
+    def __init__(self, expected_device):
+        super().__init__()
+        self.expected_device = expected_device
+
     def forward(self, image_crop):
-        assert image_crop.device.type == "mps"
+        assert image_crop.device.type == self.expected_device
         assert image_crop.shape == (1, 3, 256, 192)
         assert image_crop.is_contiguous(), (
-            "MPS backbone input must be contiguous after the width crop"
+            "Backbone input must be contiguous after the width crop"
         )
 
         batch_size = image_crop.shape[0]
@@ -139,19 +148,20 @@ class _Mano:
 class _AssertContiguous(nn.Module):
     def forward(self, img_feat):
         assert img_feat.is_contiguous(), (
-            "MPS refinement features must be contiguous before first_conv"
+            "Refinement features must be contiguous before first_conv"
         )
         return img_feat
 
 
-@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is required")
-def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps(
+@pytest.mark.parametrize("device", DEVICES)
+def test_wilor_forward_passes_contiguous_cropped_image_to_backbone(
+    device,
     lightweight_model_imports,
 ):
     WiLor, _ = lightweight_model_imports
     model = WiLor.__new__(WiLor)
     nn.Module.__init__(model)
-    model.backbone = _ContiguousBackbone()
+    model.backbone = _ContiguousBackbone(device)
     model.refine_net = _RefineNet()
     model.mano = _Mano()
     model.FOCAL_LENGTH = 5000
@@ -160,7 +170,7 @@ def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps(
     model.IMAGE_STD = torch.tensor([0.229, 0.224, 0.225]).reshape(1, 1, 1, 3)
     model.eval()
 
-    image = torch.arange(256 * 256 * 3, device="mps", dtype=torch.float32).reshape(
+    image = torch.arange(256 * 256 * 3, device=device, dtype=torch.float32).reshape(
         1, 256, 256, 3
     )
 
@@ -172,9 +182,10 @@ def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps(
 
 
 @pytest.mark.parametrize("deconv_cls_name", ["DeConvNet", "DeConvNet_v2"])
-@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is required")
-def test_refinement_deconv_makes_image_features_contiguous_before_first_conv_on_mps(
+@pytest.mark.parametrize("device", DEVICES)
+def test_refinement_deconv_makes_image_features_contiguous_before_first_conv(
     deconv_cls_name,
+    device,
     lightweight_model_imports,
 ):
     _, refinement_net = lightweight_model_imports
@@ -186,9 +197,9 @@ def test_refinement_deconv_makes_image_features_contiguous_before_first_conv_on_
         if isinstance(deconv.deconv, nn.ModuleList)
         else nn.Identity()
     )
-    deconv.to("mps")
+    deconv.to(device)
 
-    img_feat = torch.zeros(1, 4, 4, 8, device="mps").permute(0, 3, 1, 2)
+    img_feat = torch.zeros(1, 4, 4, 8, device=device).permute(0, 3, 1, 2)
     assert not img_feat.is_contiguous()
 
     deconv(img_feat)

--- a/tests/test_mps_layout.py
+++ b/tests/test_mps_layout.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+import sys
+import types
+
+import pytest
+import torch
+from torch import nn
+
+
+roma_stub = types.ModuleType("roma")
+roma_stub.rotmat_to_rotvec = lambda rotmats: torch.zeros(
+    *rotmats.shape[:-2], 3, device=rotmats.device, dtype=rotmats.dtype
+)
+sys.modules.setdefault("roma", roma_stub)
+
+vit_stub = types.ModuleType("wilor_mini.models.vit")
+vit_stub.vit = lambda **kwargs: None
+vit_stub.rot6d_to_rotmat = lambda x: x.reshape(-1, 2, 3).new_zeros(
+    x.shape[0], 3, 3
+)
+sys.modules.setdefault("wilor_mini.models.vit", vit_stub)
+
+mano_wrapper_stub = types.ModuleType("wilor_mini.models.mano_wrapper")
+mano_wrapper_stub.MANO = lambda *args, **kwargs: None
+sys.modules.setdefault("wilor_mini.models.mano_wrapper", mano_wrapper_stub)
+
+from wilor_mini.models.refinement_net import DeConvNet, DeConvNet_v2
+from wilor_mini.models.wilor import WiLor
+
+
+class _ContiguousBackbone(nn.Module):
+    def forward(self, image_crop):
+        assert image_crop.device.type == "mps"
+        assert image_crop.shape == (1, 3, 256, 192)
+        assert image_crop.is_contiguous(), (
+            "MPS backbone input must be contiguous after the width crop"
+        )
+
+        batch_size = image_crop.shape[0]
+        eye = torch.eye(3, device=image_crop.device, dtype=image_crop.dtype)
+        hand_rotmats = eye.expand(batch_size, 16, 3, 3).clone()
+        pred_mano_feats = {
+            "hand_pose": torch.zeros(
+                batch_size, 96, device=image_crop.device, dtype=image_crop.dtype
+            ),
+            "betas": torch.zeros(
+                batch_size, 10, device=image_crop.device, dtype=image_crop.dtype
+            ),
+            "cam": torch.zeros(
+                batch_size, 3, device=image_crop.device, dtype=image_crop.dtype
+            ),
+        }
+        return (
+            {
+                "global_orient": hand_rotmats[:, :1],
+                "hand_pose": hand_rotmats[:, 1:],
+                "betas": torch.zeros(
+                    batch_size, 10, device=image_crop.device, dtype=image_crop.dtype
+                ),
+            },
+            torch.ones(batch_size, 3, device=image_crop.device, dtype=image_crop.dtype),
+            pred_mano_feats,
+            torch.zeros(
+                batch_size, 1280, 16, 12, device=image_crop.device, dtype=image_crop.dtype
+            ),
+        )
+
+
+class _RefineNet(nn.Module):
+    def forward(self, img_feat, verts_3d, pred_cam, pred_mano_feats, focal_length):
+        batch_size = img_feat.shape[0]
+        eye = torch.eye(3, device=img_feat.device, dtype=img_feat.dtype)
+        hand_rotmats = eye.expand(batch_size, 16, 3, 3).clone()
+        return {
+            "global_orient": hand_rotmats[:, :1],
+            "hand_pose": hand_rotmats[:, 1:],
+            "betas": torch.zeros(
+                batch_size, 10, device=img_feat.device, dtype=img_feat.dtype
+            ),
+            "pred_cam": torch.ones(batch_size, 3, device=img_feat.device, dtype=img_feat.dtype),
+        }
+
+
+class _Mano:
+    def __call__(self, **kwargs):
+        batch_size = kwargs["betas"].shape[0]
+        device = kwargs["betas"].device
+        dtype = kwargs["betas"].dtype
+        return SimpleNamespace(
+            vertices=torch.zeros(batch_size, 778, 3, device=device, dtype=dtype),
+            joints=torch.zeros(batch_size, 21, 3, device=device, dtype=dtype),
+        )
+
+
+class _AssertContiguous(nn.Module):
+    def forward(self, img_feat):
+        assert img_feat.is_contiguous(), (
+            "MPS refinement features must be contiguous before first_conv"
+        )
+        return img_feat
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is required")
+def test_wilor_forward_passes_contiguous_cropped_image_to_backbone_on_mps():
+    model = WiLor.__new__(WiLor)
+    nn.Module.__init__(model)
+    model.backbone = _ContiguousBackbone()
+    model.refine_net = _RefineNet()
+    model.mano = _Mano()
+    model.FOCAL_LENGTH = 5000
+    model.IMAGE_SIZE = 256
+    model.IMAGE_MEAN = torch.tensor([0.485, 0.456, 0.406]).reshape(1, 1, 1, 3)
+    model.IMAGE_STD = torch.tensor([0.229, 0.224, 0.225]).reshape(1, 1, 1, 3)
+    model.eval()
+
+    image = torch.arange(256 * 256 * 3, device="mps", dtype=torch.float32).reshape(
+        1, 256, 256, 3
+    )
+
+    with torch.no_grad():
+        output = model(image)
+
+    assert output["pred_vertices"].shape == (1, 778, 3)
+    assert output["pred_keypoints_3d"].shape == (1, 21, 3)
+
+
+@pytest.mark.parametrize("deconv_cls", [DeConvNet, DeConvNet_v2])
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is required")
+def test_refinement_deconv_makes_image_features_contiguous_before_first_conv_on_mps(
+    deconv_cls,
+):
+    deconv = deconv_cls(feat_dim=8)
+    deconv.first_conv = _AssertContiguous()
+    deconv.deconv = (
+        nn.ModuleList([nn.Identity()])
+        if isinstance(deconv.deconv, nn.ModuleList)
+        else nn.Identity()
+    )
+    deconv.to("mps")
+
+    img_feat = torch.zeros(1, 4, 4, 8, device="mps").permute(0, 3, 1, 2)
+    assert not img_feat.is_contiguous()
+
+    deconv(img_feat)

--- a/wilor_mini/models/refinement_net.py
+++ b/wilor_mini/models/refinement_net.py
@@ -127,7 +127,7 @@ class DeConvNet(nn.Module):
     def forward(self, img_feat):
 
         face_img_feats = []
-        img_feat = self.first_conv(img_feat)
+        img_feat = self.first_conv(img_feat.contiguous())
         face_img_feats.append(img_feat)
         for i, deconv in enumerate(self.deconv):
             scale = 2 ** i
@@ -149,7 +149,7 @@ class DeConvNet_v2(nn.Module):
 
     def forward(self, img_feat):
         face_img_feats = []
-        img_feat = self.first_conv(img_feat)
+        img_feat = self.first_conv(img_feat.contiguous())
         img_feat = self.deconv(img_feat)
 
         return [img_feat]

--- a/wilor_mini/models/wilor.py
+++ b/wilor_mini/models/wilor.py
@@ -40,7 +40,8 @@ class WiLor(nn.Module):
         batch_size = x.shape[0]
         # Compute conditioning features using the backbone
         # if using ViT backbone, we need to use a different aspect ratio
-        temp_mano_params, pred_cam, pred_mano_feats, vit_out = self.backbone(x[:, :, :, 32:-32])  # B, 1280, 16, 12
+        backbone_input = x[:, :, :, 32:-32].contiguous()  # B, 3, 256, 192
+        temp_mano_params, pred_cam, pred_mano_feats, vit_out = self.backbone(backbone_input)  # B, 1280, 16, 12
         # Compute camera translation
         focal_length = self.FOCAL_LENGTH * torch.ones(batch_size, 2, device=x.device, dtype=x.dtype)
 


### PR DESCRIPTION
## Summary

This fixes two non-contiguous tensor boundaries that break or threaten PyTorch MPS inference on Apple Silicon:

- make the cropped ViT/backbone input contiguous after `x[:, :, :, 32:-32]`
- make refinement image features contiguous before the first convolution in both deconv variants

The patch is intentionally narrow: it does not change model weights, detector behavior, output schema, or CPU semantics.

## Verification

Base checked on 2026-05-22: `warmshao/WiLoR-mini@ebec42f94c389070cdd7dda6fd1bf0b4a659c960`. Open PR #21 was also checked (`alex-bene:deps-fix-focal-input-det-conf@cf8f582223142a57f2f486cd7b2fc0545663473d`); that PR covers dependency/API work and does not include this MPS tensor-layout repair.

Local test command:

```sh
.venv/bin/python -m pytest tests/test_mps_layout.py -q
```

Current result on PR head `e6f1ceee111b3792303c32db8168f4485eb807fa`:

```text
6 passed in 0.55s
```

The layout tests now run on CPU in ordinary CI and additionally on MPS when available. A fail-first check against base with the current test file failed on the intended non-contiguous tensor assertions for the backbone crop and both refinement deconv variants.

Saved-image smoke on Mac MPS, using `assets/img.png`, float32, `predict_with_bboxes`, and cached WiLoR-mini model artifacts:

```json
{"torch":"2.5.0","mps_built":true,"mps_available":true}
{"init_seconds":1.655}
{"elapsed_seconds":6.144,"num_outputs":1,"pred_vertices_shape":[1,778,3],"pred_keypoints_3d_shape":[1,21,3],"pred_cam_t_full_shape":[1,3],"device_route":"mps","dtype":"float32"}
```

CPU smoke with the same saved image/cache also passed:

```json
{"torch":"2.5.0","init_seconds":1.405,"elapsed_seconds":0.298,"num_outputs":1,"pred_vertices_shape":[1,778,3],"pred_keypoints_3d_shape":[1,21,3],"pred_cam_t_full_shape":[1,3],"device_route":"cpu","dtype":"float32"}
```

Dependency facts from the smoke venv:

```json
{"python":"3.10.19","torch":"2.5.0","torchvision":"0.20.0","ultralytics":"8.1.34","chumpy":"0.71","dill":"0.4.1","mps_built":true,"mps_available":true}
```

One dependency note: the detector checkpoint load required `dill`; it was not installed by the current requirements, and Ultralytics' auto-install fallback failed in a uv-created venv because `pip` was not present. I installed `dill` locally to continue the MPS smoke, but did not add that dependency here to keep this PR scoped to the tensor-layout repair.
