### PR TITLE
Avoid MPS bfloat16 cross kernel in rot6d conversion

### DIFF
--- a/tests/test_rot6d_mps_bf16.py
+++ b/tests/test_rot6d_mps_bf16.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from wilor_mini.models.vit import rot6d_to_rotmat
+
+
+def _identity_rot6d(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    return torch.tensor(
+        [[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]],
+        device=device,
+        dtype=dtype,
+    )
+
+
+def _assert_identity_rotation(out: torch.Tensor, device: torch.device, dtype: torch.dtype) -> None:
+    expected = torch.eye(3, device=device, dtype=torch.float32).unsqueeze(0)
+    assert out.shape == (1, 3, 3)
+    assert out.device.type == device.type
+    assert out.dtype == dtype
+    assert torch.isfinite(out.float()).all()
+    assert torch.allclose(out.float(), expected, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_rot6d_to_rotmat_preserves_cpu_dtype_device_and_shape(dtype: torch.dtype) -> None:
+    device = torch.device("cpu")
+    out = rot6d_to_rotmat(_identity_rot6d(device, dtype))
+    _assert_identity_rotation(out, device, dtype)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is not available")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_rot6d_to_rotmat_preserves_mps_dtype_device_and_shape(dtype: torch.dtype) -> None:
+    device = torch.device("mps")
+    out = rot6d_to_rotmat(_identity_rot6d(device, dtype))
+    torch.mps.synchronize()
+    _assert_identity_rotation(out, device, dtype)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is not available")
+def test_rot6d_to_rotmat_supports_mps_bfloat16_without_cross_kernel() -> None:
+    device = torch.device("mps")
+    out = rot6d_to_rotmat(_identity_rot6d(device, torch.bfloat16))
+    torch.mps.synchronize()
+    _assert_identity_rotation(out, device, torch.bfloat16)
+
+
+def test_rot6d_to_rotmat_manual_cross_remains_differentiable_on_cpu() -> None:
+    x = _identity_rot6d(torch.device("cpu"), torch.float32).requires_grad_(True)
+    out = rot6d_to_rotmat(x)
+    out.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()

--- a/wilor_mini/models/vit.py
+++ b/wilor_mini/models/vit.py
@@ -24,7 +24,12 @@ def rot6d_to_rotmat(x: torch.Tensor) -> torch.Tensor:
     a2 = x[:, :, 1]
     b1 = F.normalize(a1)
     b2 = F.normalize(a2 - torch.einsum('bi,bi->b', b1, a2).unsqueeze(-1) * b1)
-    b3 = torch.linalg.cross(b1, b2)
+    # Manual cross product keeps MPS bfloat16 on-device where torch.linalg.cross is unsupported.
+    b3 = torch.stack((
+        b1[:, 1] * b2[:, 2] - b1[:, 2] * b2[:, 1],
+        b1[:, 2] * b2[:, 0] - b1[:, 0] * b2[:, 2],
+        b1[:, 0] * b2[:, 1] - b1[:, 1] * b2[:, 0],
+    ), dim=-1)
     return torch.stack((b1, b2, b3), dim=-1)
 
 


### PR DESCRIPTION
## Summary
- replace `torch.linalg.cross` in `rot6d_to_rotmat` with the equivalent elementwise 3D cross product
- add focused rot6d dtype/device coverage, including an MPS bfloat16 regression test when MPS is available
- add a small CPU autograd smoke for the rotation conversion path

## Why
On MPS with bfloat16 and fallback disabled, `torch.linalg.cross` can fail with `RuntimeError: Failed to create function state object for: cross_bfloat`. The explicit cross-product formula uses basic tensor operations, preserves dtype/device, and keeps the operation on-device for MPS bfloat16.

This is separate from #22 and only addresses the `cross_bfloat` compatibility failure. It is not intended as a performance optimization.

## Tests
- `PYTORCH_ENABLE_MPS_FALLBACK=0 uv run --with pytest --python .venv/bin/python pytest tests/test_rot6d_mps_bf16.py -q`
- `PYTORCH_ENABLE_MPS_FALLBACK=0 .venv/bin/python - <<'PY' ... rot6d_to_rotmat(..., device='mps', dtype=torch.bfloat16) ... PY`
- `.venv/bin/python -m py_compile wilor_mini/models/vit.py tests/test_rot6d_mps_bf16.py`